### PR TITLE
Fix accommodation types display to properly handle string values

### DIFF
--- a/frontend_app/app/frontend/components.py
+++ b/frontend_app/app/frontend/components.py
@@ -66,11 +66,19 @@ def format_filters(params) -> str:
             if options is None:
                 continue
 
-            for option in options:
+            # Special handling for accommodation types - when options is a string (not a list)
+            if column == "accomodation_types" and isinstance(options, str):
                 if "include" in suffix:
-                    options_highlighted.append(f":blue-background[{option}]")
+                    options_highlighted.append(f":blue-background[{options}]")
                 else:
-                    options_highlighted.append(f"~~:red-background[{option}]~~")
+                    options_highlighted.append(f"~~:red-background[{options}]~~")
+            # Normal handling for other cases
+            else:
+                for option in options:
+                    if "include" in suffix:
+                        options_highlighted.append(f":blue-background[{option}]")
+                    else:
+                        options_highlighted.append(f"~~:red-background[{option}]~~")
 
         if not options_highlighted:
             continue


### PR DESCRIPTION
accommodation_types can be of type str instead of list[str] so this implements this check and fixes this

**Before**
![image](https://github.com/user-attachments/assets/23a45a27-5742-41f6-90f6-66acf8c76bad)

**After**

![image](https://github.com/user-attachments/assets/0ba9f7d6-82ca-4111-a5d2-3970cd43fe74)

